### PR TITLE
Finish API's MongoDB implementation (with examples)

### DIFF
--- a/api/api_gets.py
+++ b/api/api_gets.py
@@ -14,3 +14,18 @@ def listUsers():
 
     # Return new response object formatted with users
     return Response(200, users).serialize()
+
+# /users/<count>
+@app.route('/users/<int:count>')
+def listUserCount(count):
+    users = list(mongo.db.users.find({}).limit(count))
+    return Response(200, users).serialize()
+
+# /randUsers
+@app.route('/randUsers')
+def listRandomUsers():
+    # Search for random 5 users and typecast to list
+    users = list(mongo.db.users.aggregate([ { "$sample": { "size": 5 } } ]))
+
+    # Return new response object formatted with users
+    return Response(200, users).serialize()

--- a/api/api_gets.py
+++ b/api/api_gets.py
@@ -1,0 +1,16 @@
+from api_main import app, mongo
+from response import Response
+
+# Index
+@app.route('/')
+def index():
+    return Response(200, {}).serialize()
+
+# /users
+@app.route('/users')
+def listUsers():
+    # Search for first 10 users and typecast to list
+    users = list(mongo.db.users.find({}).limit(10))
+
+    # Return new response object formatted with users
+    return Response(200, users).serialize()

--- a/api/api_main.py
+++ b/api/api_main.py
@@ -3,7 +3,6 @@ import configparser
 from bson import json_util
 from flask import Flask
 from flask_pymongo import PyMongo
-from response import Response
 
 # Read Config
 config = configparser.ConfigParser()
@@ -16,15 +15,6 @@ app = Flask(__name__)
 app.config["MONGO_URI"] = config['MongoDB']['URI']
 mongo = PyMongo(app)
 
-# Start Routes
-@app.route('/')
-def index():
-    return Response(200, {}).serialize()
-
-@app.route('/users')
-def listUsers():
-    # Search for first 10 users and typecast to list
-    users = list(mongo.db.users.find({}).limit(10))
-
-    # Return new response object formatted with users
-    return Response(200, users).serialize()
+# Now that app is initialized, import other paths
+# Import all get requests
+import api_gets

--- a/api/api_main.py
+++ b/api/api_main.py
@@ -1,4 +1,6 @@
+import json
 import configparser
+from bson import json_util
 from flask import Flask
 from flask_pymongo import PyMongo
 from response import Response
@@ -17,4 +19,20 @@ mongo = PyMongo(app)
 # Start Routes
 @app.route('/')
 def index():
-    return Response(200, {}).__dict__
+    return Response(200, {}).serialize()
+
+@app.route('/users')
+def listUsers():
+    # Search for first 10 users
+    cursor = list(mongo.db.users.find({}).limit(10))
+
+    # Because find() returns a cursor, we need to serialize it.
+    # Cursor contains docs. Iterate thru and compile into one dict.
+    users = json_util.dumps(cursor)
+
+    # Return users
+    return app.response_class(
+        response=Response(200, cursor).serialize(),
+        status=200,
+        mimetype='application/json'
+    )

--- a/api/api_main.py
+++ b/api/api_main.py
@@ -23,16 +23,8 @@ def index():
 
 @app.route('/users')
 def listUsers():
-    # Search for first 10 users
-    cursor = list(mongo.db.users.find({}).limit(10))
+    # Search for first 10 users and typecast to list
+    users = list(mongo.db.users.find({}).limit(10))
 
-    # Because find() returns a cursor, we need to serialize it.
-    # Cursor contains docs. Iterate thru and compile into one dict.
-    users = json_util.dumps(cursor)
-
-    # Return users
-    return app.response_class(
-        response=Response(200, cursor).serialize(),
-        status=200,
-        mimetype='application/json'
-    )
+    # Return new response object formatted with users
+    return Response(200, users).serialize()

--- a/api/response.py
+++ b/api/response.py
@@ -1,3 +1,5 @@
+from bson import json_util
+
 class Response:
     def __init__(self, code, data, *args):
         # An HTTP Response code
@@ -9,10 +11,14 @@ class Response:
         self.message = getResponseData(code)['message']
 
         # Pass thru data from constructor.
+        #print("data = ", data)
         self.data = data
 
         # Pass thru optional errorData dict, to help describe an error.
         self.errorData = args[0] if len(args)>0 else {}
+
+    def serialize(self):
+        return json_util.dumps(self.__dict__)
 
 def getResponseData(code):
     # Dict containing all possible response codes

--- a/api/response.py
+++ b/api/response.py
@@ -18,7 +18,7 @@ class Response:
         self.errorData = args[0] if len(args)>0 else {}
 
     def serialize(self):
-        return json_util.dumps(self.__dict__)
+        return json_util.dumps(self.__dict__), {'Content-Type': 'application/json; charset=utf-8'}
 
 def getResponseData(code):
     # Dict containing all possible response codes


### PR DESCRIPTION
Finished engineering the groundwork for the API. A lot simpler than I thought it would have been. 
- Added `Response.serialize()`, which replaces the usage of `Response.__dict__`. 
    - Serializes an initialized Response object.
- Modularized the route files using circular imports. (Gross, I know, but Flask allows it.)
- Added a few examples of endpoints using MongoDB queries and/or aggregation.