### PR TITLE
Add handling for pymongo SRV and Authentication errors

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -14,11 +14,8 @@ To run the server, You'll need to set some environment variables.
 ```
 $ cd CreatorConnect/api/
 $ pip install -r requirements.txt
-$ export FLASK_ENV=development
-$ export FLASK_APP=hello.py
+$ python run_server.py
 ```
-
-*Note: on Windows, use `set` instead of `export`. Also, you may need to re-run the export commands every time you run the app in a new terminal instance.*
 
 Now, run the server using `flask run`!
 

--- a/api/api_main.py
+++ b/api/api_main.py
@@ -1,8 +1,10 @@
+import sys
 import json
 import configparser
 from bson import json_util
 from flask import Flask
 from flask_pymongo import PyMongo
+from pymongo.errors import ConfigurationError, OperationFailure
 
 # Read Config
 config = configparser.ConfigParser()
@@ -11,10 +13,27 @@ config.read('config.ini')
 # Init Flask App
 app = Flask(__name__)
 
-# Init MongoDB Connection
+# Init MongoDB Connection and run sample query to test authentication
 app.config["MONGO_URI"] = config['MongoDB']['URI']
-mongo = PyMongo(app)
+try:
+    mongo = PyMongo(app)
+    list(mongo.db.users.find({}).limit(1))
+except ConfigurationError as err:
+    if (err.args[0] == "A DNS label is empty."):
+        print("[ERROR]: MongoDB URI returning SRV error. If you're on the FSUSecure")
+        print("         network, we recommend using the expanded URI to circumvent")
+        print("         this error.")
+    sys.exit(1)
+except OperationFailure as err:
+    if (err.args[0] == "bad auth Authentication failed."):
+        print("[ERROR]: MongoDB URI returning authentication error. Make sure you")
+        print("         are using a URI with a valid username/password combo.")
+    sys.exit(1)
+
 
 # Now that app is initialized, import other paths
 # Import all get requests
 import api_gets
+
+if __name__ == '__main__':
+    app.run()

--- a/api/run_server.py
+++ b/api/run_server.py
@@ -1,0 +1,11 @@
+import platform, os
+from api_main import app
+
+if (platform.system() == "Windows"):
+   cmd = "set"
+else:
+    cmd = "export" 
+
+os.system("{} FLASK_APP=api_main.py".format(cmd))
+os.system("{} FLASK_ENV=development".format(cmd))
+app.run()


### PR DESCRIPTION
This pull requests adds handling for some of the errors outlined in #18.
- If SRV record doesn't connect, (i.e. you're on FSU wifi) prevent app from launching.
- If authentication is invalid, prevent app from launching.

**NOTE: This bug fix changes the way that the server is initialized! While the old method still runs the app, you may encounter faults in error handling! I've updated the documentation to reflect the new way to run the API.**